### PR TITLE
Add wallaby.js config

### DIFF
--- a/wallaby.js
+++ b/wallaby.js
@@ -1,0 +1,22 @@
+module.exports = function() {
+  return {
+    files: [
+      'src/**/*.ts',
+      '__tests__/utils/*.ts',
+      '!src/**/*.spec.ts',
+      {
+        pattern: '__tests__/samples/**/*',
+        instrument: false
+      }
+    ],
+
+    tests: ['src/**/*.spec.ts', '!src/cli/*.spec.ts'],
+
+    env: {
+      type: 'node',
+      runner: 'node'
+    },
+
+    testFramework: 'jest'
+  };
+};


### PR DESCRIPTION
This allows running the unit-tests with [wallaby](https://wallabyjs.com/). I excluded the CLI tests from the config as they don't play nicely with wallaby.